### PR TITLE
[DnC] BJ DNC (4) - multiple

### DIFF
--- a/Devide_and_Conquer/bj_devide_and_conquer.py
+++ b/Devide_and_Conquer/bj_devide_and_conquer.py
@@ -1,19 +1,30 @@
 # 곱셈
-def multiple_dnc():
-    import sys
-    a, b, c = map(int, sys.stdin.readline().split())
-
-    def multi(a, n):
-        if n == 1:
-            return a % c
+def multiple_dnc_vers2():
+    a,b,c=map(int,input().split())
+    
+    def dnc(a,b,c):
+        if b==1:
+            return a%c
+        elif b%2==0:
+            return (dnc(a,b//2,c)**2)%c
         else:
-            tmp = multi(a, n // 2)
-            if n % 2 == 0:
-                return (tmp * tmp) % c
-            else:
-                return (tmp * tmp * a) % c
+            return ((dnc(a,b//2,c)**2)*a)%c
+            
+    print(dnc(a,b,c))
 
-    print(multi(a, b))
+
+# RecursionError
+def multiple_dnc_vers1():
+    a,b,c=map(int,input().split())
+    
+    def rcrs(a,aa,time,div):
+        if time==0:
+            print(aa)
+            return
+        rcrs(a,a*aa%div,time-1,div)
+        
+    rcrs(a,1,b,c)
+
 
 
 # 종이의 개수


### PR DESCRIPTION
## 배운 점
#### N 번 곱셈의 시간 줄이는 방법
예를 들어, 2^32라면 2를 32번 곱하는 방법도 있지만, (2^16)^2로 해서 풀면 2를 16번 곱한 것을 다시 2번 곱하니 17번의 연산만으로 끝낼 수 있어 시간이 훨씬 적게 든다. 이를 계속 해보면 {(2^8)^2}^2 이렇게 풀면 10번만에, [{(2^4)^2}^2]^2 이렇게 풀면 7번만에 끝낼 수 있어 시간이 획기적으로 주는 것이다.